### PR TITLE
Fix call to hasDefine in tests.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,16 +14,13 @@
     "tests"
   ],
   "devDependencies": {
-    "moment": "~2.6.0",
-    "ember-data": "~0.0.14",
+    "moment": "2.8.3",
+    "ember-data": "1.0.0-beta.9",
     "ember-load-initializers": "https://github.com/stefanpenner/ember-load-initializers.git#~0.0.1",
-    "ember-resolver": "~0.0.1",
+    "ember-resolver": "v0.1.7",
     "handlebars": "~1.3.0",
-    "qunit": "~1.14.0",
-    "ic-ajax": "~1.0.4",
+    "qunit": "~1.15.0",
+    "ic-ajax": "v2.0.1",
     "d3": "3.4.8"
-  },
-  "resolutions": {
-    "ember": ">=1.4 <2"
   }
 }

--- a/tests/anonymous-identifier-test.js
+++ b/tests/anonymous-identifier-test.js
@@ -11,7 +11,7 @@ describe('Leaf - annonmous with identifier', function() {
     var m = new Leaf('./tests/fixtures/anonymous-identifier.js', source);
     var remappedLeaf;
 
-    assert(m.hasDefine, 'expected module to have a define');
+    assert(m.hasDefine(), 'expected module to have a define');
     assert(m.isAnonymous, 'expected module to not be named');
 
     expect(m.imports).to.deep.equal({

--- a/tests/anonymous-test.js
+++ b/tests/anonymous-test.js
@@ -11,7 +11,7 @@ describe('Leaf - annonmous', function() {
     var m = new Leaf('./tests/fixtures/anonymous.js', source);
     var remapped;
 
-    assert(m.hasDefine, true, 'module has define property');
+    assert(m.hasDefine(), 'module has define property');
     assert.equal(m.isAnonymous, true, 'module is not named');
 
     remapped = m.remap('foobarbaz');

--- a/tests/anonymous-with-call-expression-test.js
+++ b/tests/anonymous-with-call-expression-test.js
@@ -10,7 +10,7 @@ describe('Leaf - annonmous', function() {
     var source = fs.readFileSync('./tests/fixtures/anonymous-call-expression.js');
     var m = new Leaf('./tests/fixtures/anonymous-call-expression.js', source);
     var remapped;
-    assert(m.hasDefine, 'expected module to have a define');
+    assert(m.hasDefine(), 'expected module to have a define');
     assert(m.isAnonymous, 'expected module to not be named');
 
     expect(m.imports).to.deep.equal({

--- a/tests/anonymous-with-deps-test.js
+++ b/tests/anonymous-with-deps-test.js
@@ -10,7 +10,7 @@ describe('Leaf - anoymous', function() {
     var source = fs.readFileSync('./tests/fixtures/anonymous-with-deps.js');
     var m = new Leaf('./tests/fixtures/anonymous-with-deps.js', source);
 
-    assert(m.hasDefine, 'expected module to have a define');
+    assert(m.hasDefine(), 'expected module to have a define');
     assert(m.isAnonymous, 'expected module to not be named');
 
     expect(m.imports).to.deep.equal({

--- a/tests/d3-test.js
+++ b/tests/d3-test.js
@@ -7,7 +7,7 @@ describe('Leaf - d3', function() {
     var source = fs.readFileSync('bower_components/d3/d3.js');
     var m = new Leaf('bower_components/d3/d3.js', source);
 
-    assert(m.hasDefine, true, 'module has define property');
+    assert(m.hasDefine(), 'module has define property');
     assert.equal(m.isAnonymous, true, 'module is not named');
   });
 });

--- a/tests/ember-data-test.js
+++ b/tests/ember-data-test.js
@@ -8,7 +8,7 @@ describe('Leaf - ember-data (brings its own embeded loader)', function() {
     var source = fs.readFileSync('bower_components/ember-data/ember-data.js');
     var m = new Leaf('bower_components/ember-data/ember-data.js', source);
 
-    assert(m.hasDefine, false, 'no module is defined');
+    assert(m.hasDefine(), 'module has define property');
     assert.equal(m.isAnonymous, undefined, 'module is anonymous');
 
     expect(m.imports).to.deep.equal({ });

--- a/tests/ember-load-initializer-test.js
+++ b/tests/ember-load-initializer-test.js
@@ -8,7 +8,7 @@ describe('Leaf - ember/load-initializers', function() {
     var source = fs.readFileSync('bower_components/ember-load-initializers/ember-load-initializers.js');
     var m = new Leaf('bower_components/ember-load-initializers/ember-load-initializers.js', source);
 
-    assert(m.hasDefine, true, 'no module is defined');
+    assert(m.hasDefine(), 'no module is defined');
     assert.equal(m.isAnonymous, false, 'module is anonymous');
 
     expect(m.imports).to.deep.equal({

--- a/tests/ember-resolver-test.js
+++ b/tests/ember-resolver-test.js
@@ -8,15 +8,19 @@ describe('Leaf - ember/resolver', function() {
     var source = fs.readFileSync('bower_components/ember-resolver/dist/ember-resolver.js');
     var m = new Leaf('bower_components/ember-resolver/dist/ember-resolver.js', source);
 
-    assert(m.hasDefine, true, 'no module is defined');
+    assert(m.hasDefine(), 'no module is defined');
     assert.equal(m.isAnonymous, false, 'module is anonymous');
 
     expect(m.imports).to.deep.equal({
-      'resolver': []
+      'ember/resolver': [],
+      resolver: [ 'ember/resolver' ],
+      'ember/container-debug-adapter': []
     });
 
     expect(m.exports).to.deep.equal({
-      'resolver': ['default']
+      'ember/resolver': [ 'default' ],
+      resolver: [ 'default' ],
+      'ember/container-debug-adapter': [ 'default' ]
     });
   });
 });

--- a/tests/ember-test.js
+++ b/tests/ember-test.js
@@ -8,7 +8,7 @@ describe('Leaf - ember (brings its own embeded loader)', function() {
     var source = fs.readFileSync('bower_components/ember/ember.js');
     var m = new Leaf('bower_components/ember/ember.js', source);
 
-    assert(m.hasDefine, false, 'no module is defined');
+    assert(m.hasDefine(), false, 'no module is defined');
     assert.equal(m.isAnonymous, undefined, 'module is anonymous');
 
     expect(m.imports).to.deep.equal({ });

--- a/tests/exports-with-multiple-exports-test.js
+++ b/tests/exports-with-multiple-exports-test.js
@@ -8,7 +8,7 @@ describe('Leaf - variable export var name', function() {
     var source = fs.readFileSync('./tests/fixtures/multiple-property-exports.js');
     var m = new Leaf('./tests/fixtures/multiple-property-exports.js', source);
 
-    assert(m.hasDefine, false, 'no module is defined');
+    assert(m.hasDefine(), false, 'no module is defined');
     assert.equal(m.isAnonymous, false, 'module is anonymous');
 
     expect(m.imports).to.deep.equal({

--- a/tests/exports-with-variable-export-name-test.js
+++ b/tests/exports-with-variable-export-name-test.js
@@ -8,7 +8,7 @@ describe('Leaf - variable export var name', function() {
     var source = fs.readFileSync('./tests/fixtures/exports-with-variable-name.js');
     var m = new Leaf('./tests/fixtures/exports-with-variable-export-name.js', source);
 
-    assert(m.hasDefine, false, 'no module is defined');
+    assert(m.hasDefine(), false, 'no module is defined');
     assert.equal(m.isAnonymous, false, 'module is anonymous');
 
     expect(m.imports).to.deep.equal({

--- a/tests/handlebars-remap-test.js
+++ b/tests/handlebars-remap-test.js
@@ -9,7 +9,7 @@ describe('Leaf - handlebars remap:', function() {
     var m = new Leaf('bower_components/handlebars/handlebars.amd.js', source);
     var remappedLeaf;
 
-    assert(m.hasDefine, true, 'no module is defined');
+    assert(m.hasDefine(), 'no module is defined');
     assert.equal(m.isAnonymous, false, 'module is anonymous');
 
     remappedLeaf = m.remap('handlebars@2.0.0');

--- a/tests/handlebars-test.js
+++ b/tests/handlebars-test.js
@@ -8,7 +8,7 @@ describe('Leaf - handlebars', function() {
     var source = fs.readFileSync('bower_components/handlebars/handlebars.amd.js');
     var m = new Leaf('bower_components/handlebars/handlebars.amd.js', source);
 
-    assert(m.hasDefine, true, 'no module is defined');
+    assert(m.hasDefine(), 'no module is defined');
     assert.equal(m.isAnonymous, false, 'module is anonymous');
 
     expect(m.exports).to.deep.equal({

--- a/tests/htmlbars-remap-test.js
+++ b/tests/htmlbars-remap-test.js
@@ -9,7 +9,7 @@ describe('Leaf - htmlbars remap:', function() {
     var m = new Leaf('vendor/htmlbars-runtime.amd.js', source);
     var remappedLeaf;
 
-    assert(m.hasDefine, true, 'no module is defined');
+    assert(m.hasDefine(), 'no module is defined');
     assert.equal(m.isAnonymous, false, 'module is anonymous');
 
     remappedLeaf = m.remap('htmlbars-runtime@2.0.0');

--- a/tests/htmlbars-test.js
+++ b/tests/htmlbars-test.js
@@ -8,7 +8,7 @@ describe('Leaf - htmlbars', function() {
     var source = fs.readFileSync('vendor/htmlbars-runtime.amd.js');
     var m = new Leaf('vendor/htmlbars-runtime.amd.js', source);
 
-    assert(m.hasDefine, true, 'no module is defined');
+    assert(m.hasDefine(), 'no module is defined');
     assert.equal(m.isAnonymous, false, 'module is anonymous');
 
     expect(m.exports).to.deep.equal({

--- a/tests/ic-ajax-test.js
+++ b/tests/ic-ajax-test.js
@@ -8,7 +8,7 @@ describe('Leaf - ic-ajax', function() {
     var source = fs.readFileSync('bower_components/ic-ajax/dist/amd/main.js');
     var m = new Leaf('bower_components/ic-ajax/dist/amd/main.js', source);
 
-    assert(m.hasDefine, true, 'module has define property');
+    assert(m.hasDefine(), 'module has define property');
     assert.equal(m.isAnonymous, true, 'module is named');
     expect(m.imports).to.deep.equal({
       '.': [

--- a/tests/jquery-test.js
+++ b/tests/jquery-test.js
@@ -8,7 +8,7 @@ describe('Leaf - jquery', function() {
     var source = fs.readFileSync('bower_components/jquery/dist/jquery.js');
     var m = new Leaf('bower_components/jquery/dist/jquery.js', source);
 
-    assert(m.hasDefine, true, 'module has define property');
+    assert(m.hasDefine(), 'module has define property');
     assert.equal(m.isAnonymous, false, 'module is named');
 
     expect(m.imports).to.deep.equal({

--- a/tests/moment-test.js
+++ b/tests/moment-test.js
@@ -8,7 +8,7 @@ describe('Leaf - moment', function() {
     var source = fs.readFileSync('bower_components/moment/moment.js');
     var m = new Leaf('bower_components/moment/moment.js', source);
 
-    assert(m.hasDefine, true, 'no module is defined');
+    assert(m.hasDefine(), 'no module is defined');
     assert.equal(m.isAnonymous, false, 'module is anonymous');
     assert.deepEqual(m.imports, {
       'moment': []
@@ -23,7 +23,7 @@ describe('Leaf - moment', function() {
     var source = fs.readFileSync('bower_components/moment/moment.js');
     var m = new Leaf('bower_components/moment/moment.js', source);
 
-    assert(m.hasDefine, true, 'no module is defined');
+    assert(m.hasDefine(), 'no module is defined');
     assert.equal(m.isAnonymous, false, 'module is anonymous');
     assert.deepEqual(m.imports, {
       'moment': []
@@ -56,7 +56,7 @@ describe('Leaf - moment', function() {
     var source = fs.readFileSync('bower_components/moment/min/moment.min.js');
     var m = new Leaf('bower_components/moment/min/moment.js', source);
 
-    assert(m.hasDefine, true, 'no module is defined');
+    assert(m.hasDefine(), 'no module is defined');
     assert.equal(m.isAnonymous, false, 'module is anonymous');
 
     expect(m.imports).to.deep.equal({

--- a/tests/non-local-remap-test.js
+++ b/tests/non-local-remap-test.js
@@ -9,7 +9,7 @@ describe('Leaf - non local remap', function() {
     var m = new Leaf('vendor/htmlbars-runtime.amd.js', source);
     var remappedLeaf;
 
-    assert(m.hasDefine, true, 'module is defined');
+    assert(m.hasDefine(), 'module is defined');
     assert.equal(m.isAnonymous, false, 'module isnt anonymous');
 
     remappedLeaf = m.remap('htmlbars-runtime@2.0.0', {

--- a/tests/own-loader-test.js
+++ b/tests/own-loader-test.js
@@ -8,7 +8,7 @@ describe('Leaf - own loader', function() {
     var source = fs.readFileSync('tests/fixtures/own-loader.js');
     var m = new Leaf('tests/fixtures/own-loader.js', source);
 
-    assert(m.hasDefine, false, 'no module is defined');
+    assert(m.hasDefine(), false, 'no module is defined');
     assert.equal(m.isAnonymous, undefined, 'module is anonymous');
 
     expect(m.imports).to.deep.equal({ });

--- a/tests/qunit-test.js
+++ b/tests/qunit-test.js
@@ -8,7 +8,7 @@ describe('Leaf - qunit', function() {
     var source = fs.readFileSync('bower_components/qunit/qunit/qunit.js');
     var m = new Leaf('bower_components/qunit/qunit/qunit.js', source);
 
-    assert(m.hasDefine, false, 'no module is defined');
+    assert.equal(m.hasDefine(), false, 'no module is defined');
     assert.equal(m.isAnonymous, undefined, 'module is anonymous');
 
     expect(m.imports).to.deep.equal({ });


### PR DESCRIPTION
- Updates test to use `hasDefine()` instead of `hasDefine`
- Updates bower dependencies, use exact versions.
